### PR TITLE
fix: skip notification when no apprise services are configured

### DIFF
--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -366,6 +366,12 @@ class Appriser:
             logger.trace("No logs to send")
             return
 
+        if not len(self.apprise_obj):
+            # No services configured: skip notifying so apprise doesn't log
+            # "There are no service(s) to notify" for every flush.
+            logger.trace("No notification services configured; skipping notification")
+            return
+
         # Format the buffered logs into a single message
         message = "".join(self.buffer).replace("\r", "")
 

--- a/tests/test_apprise_cannot_handle_notification.py
+++ b/tests/test_apprise_cannot_handle_notification.py
@@ -3,6 +3,7 @@ import threading
 from threading import ExceptHookArgs
 
 from apprise import Apprise
+from conftest import NoOpNotifier
 
 from logprise import Appriser
 
@@ -21,7 +22,8 @@ def test_uncaught_exception_hook_with_non_default_existing_hook(mocker):
 
     assert sys.excepthook == my_global_exception_hook
 
-    Appriser()
+    appriser = Appriser()
+    appriser.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
 
     assert sys.excepthook != my_global_exception_hook, "Exception hook was not replaced."
 
@@ -37,7 +39,8 @@ def test_uncaught_exception_hook_with_default_existing_hook(mocker):
     """Test that uncaught exceptions trigger immediate notifications."""
     mock_send = mocker.patch.object(Apprise, "notify", side_effect=Exception)
 
-    Appriser()
+    appriser = Appriser()
+    appriser.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
 
     # Simulate an uncaught exception
     sys.excepthook(ValueError, ValueError("Test exception"), None)
@@ -60,7 +63,8 @@ def test_uncaught_threading_exception_hook_with_non_default_existing_hook(mocker
 
     assert threading.excepthook == my_global_exception_hook
 
-    Appriser()
+    appriser = Appriser()
+    appriser.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
 
     assert threading.excepthook != my_global_exception_hook, "Exception hook was not replaced."
 
@@ -76,7 +80,8 @@ def test_uncaught_threading_exception_hook_with_default_existing_hook(mocker):
     """Test that uncaught exceptions trigger immediate notifications."""
     mock_send = mocker.patch.object(Apprise, "notify", side_effect=Exception)
 
-    Appriser()
+    appriser = Appriser()
+    appriser.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
 
     # Simulate an uncaught exception
     threading.excepthook(ExceptHookArgs((ValueError, ValueError("Test exception"), None, None)))
@@ -89,6 +94,8 @@ def test_multiple_apprise_objects_with_non_default_existing_hook(mocker):
     """Test that uncaught exceptions trigger immediate notifications."""
     mock_send = mocker.patch.object(Apprise, "notify", side_effect=Exception)
     _1 = Appriser()
+    _1.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
     _2 = Appriser()
+    _2.add(NoOpNotifier())
     sys.excepthook(ValueError, ValueError("Test exception"), None)
     mock_send.assert_called_once()

--- a/tests/test_logprise.py
+++ b/tests/test_logprise.py
@@ -88,6 +88,25 @@ def test_send_notification_empty():
     assert len(appriser.buffer) == 0
 
 
+def test_send_notification_skipped_when_no_services(mocker):
+    """With logs buffered but no services configured, apprise.notify is never called.
+
+    This avoids apprise logging 'There are no service(s) to notify' on every flush.
+    """
+    appriser = Appriser(apprise_trigger_level="ERROR")
+    assert len(appriser.apprise_obj) == 0  # no services configured
+
+    logger.error("Boom")
+    assert len(appriser.buffer) == 1
+
+    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    appriser.send_notification()
+
+    mock_notify.assert_not_called()
+    # The buffered log is retained, not silently dropped.
+    assert len(appriser.buffer) == 1
+
+
 def test_config_file_loading(tmp_path, mocker):
     """Test that Appriser can load config from filesystem"""
     # Mock DEFAULT_CONFIG_PATHS to only use our temp directory


### PR DESCRIPTION
## Problem

When logs are buffered (e.g. an error was logged) but **no notification services are configured**, `send_notification()` still calls `apprise.notify()`. Apprise then logs `There are no service(s) to notify` at ERROR level on every flush — which logprise intercepts and surfaces to the user. If you haven't configured any services, you don't want to see this.

## Fix

`Appriser.send_notification()` now returns early when `len(self.apprise_obj) == 0`, before reaching `notify()`. Buffered logs are retained rather than dropped.

## Tests

- Added `test_send_notification_skipped_when_no_services` verifying `notify()` is never called when no services are configured (and the buffer is preserved).
- The uncaught-exception hook tests previously relied on `notify()` being called with no services configured; they now register a no-op service (`NoOpNotifier`) so the path they assert on is actually reachable.