### PR TITLE
refactor: decouple Appriser construction from activation via install()

### DIFF
--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -94,6 +94,7 @@ class Appriser:
         recursion_depth: int = apprise.cli.DEFAULT_RECURSION_DEPTH,
         flush_interval: float = 3600,
     ) -> None:
+        self._installed: bool = False
         self._flush_thread: threading.Thread | None = None
         self._stop_event: threading.Event = threading.Event()
 
@@ -108,7 +109,19 @@ class Appriser:
         self.apprise_obj: apprise.Apprise = apprise.Apprise()
         self.buffer: list[loguru.Message] = []
 
-        # Initialize everything
+    def install(self) -> None:
+        """Arm every process-global side effect of this Appriser.
+
+        Constructing an :class:`Appriser` only sets up instance-local state.
+        This method installs the logging interception, the sys/threading
+        exception hooks, the loguru removal prevention, the atexit cleanup, and
+        starts the periodic flush thread. It is idempotent: calling it more than
+        once is a no-op.
+        """
+        if self._installed:
+            return
+        self._installed = True
+
         self._load_default_config_paths()
         self._setup_interception_handler()
         self._setup_sys_exception_hook()
@@ -281,8 +294,9 @@ class Appriser:
 
         if self._flush_interval != value:
             self._flush_interval = value
-            self.stop_periodic_flush()
-            self._start_periodic_flush()
+            if self._installed:
+                self.stop_periodic_flush()
+                self._start_periodic_flush()
 
     def _periodic_flush(self) -> None:
         """Periodically flush log buffer."""
@@ -392,3 +406,4 @@ class Appriser:
 
 
 appriser = Appriser()
+appriser.install()

--- a/logprise/__init__.pyi
+++ b/logprise/__init__.pyi
@@ -32,6 +32,7 @@ class Appriser:
         recursion_depth: int = ...,
         flush_interval: float = 3600,
     ) -> None: ...
+    def install(self) -> None: ...
     def add(
         self,
         servers: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,29 @@ class NoOpNotifier(NotifyBase):
         return True
 
 
+def make_appriser(*, add_noop: bool = False, **kwargs: Any) -> Appriser:
+    """Build an Appriser and arm it, exactly as importing the package does.
+
+    Constructing an Appriser only sets up instance-local state; ``install()``
+    performs the process-global side effects (logging interception, exception
+    hooks, the flush thread). Tests that exercise that behavior need an armed
+    instance, so route every construction through this helper.
+
+    Pass ``add_noop=True`` to also configure a NoOpNotifier, for tests that need
+    a service present (so ``notify()`` is actually attempted) but don't need a
+    handle on it. Tests that need the notifier handle should use the
+    ``apprise_noop`` fixture instead.
+    """
+    appriser = Appriser(**kwargs)
+    appriser.install()
+    if add_noop:
+        appriser.add(NoOpNotifier())
+    return appriser
+
+
 @pytest.fixture
 def apprise_noop() -> Generator[tuple[Appriser, NoOpNotifier], Any, None]:
-    a = Appriser()
+    a = make_appriser()
     noop = NoOpNotifier()
     a.add(noop)
     try:

--- a/tests/test_adding_add_method.py
+++ b/tests/test_adding_add_method.py
@@ -1,9 +1,9 @@
-from logprise import Appriser
+from conftest import make_appriser
 
 
 def test_add_method(mocker):
     """Test that add method correctly passes through to apprise_obj.add"""
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # Create a mock for the underlying apprise_obj.add method
     mock_add = mocker.patch.object(appriser.apprise_obj, "add", return_value=True)

--- a/tests/test_apprise_cannot_handle_notification.py
+++ b/tests/test_apprise_cannot_handle_notification.py
@@ -3,9 +3,7 @@ import threading
 from threading import ExceptHookArgs
 
 from apprise import Apprise
-from conftest import NoOpNotifier
-
-from logprise import Appriser
+from conftest import make_appriser
 
 
 def test_uncaught_exception_hook_with_non_default_existing_hook(mocker):
@@ -22,8 +20,7 @@ def test_uncaught_exception_hook_with_non_default_existing_hook(mocker):
 
     assert sys.excepthook == my_global_exception_hook
 
-    appriser = Appriser()
-    appriser.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
+    make_appriser(add_noop=True)
 
     assert sys.excepthook != my_global_exception_hook, "Exception hook was not replaced."
 
@@ -39,8 +36,7 @@ def test_uncaught_exception_hook_with_default_existing_hook(mocker):
     """Test that uncaught exceptions trigger immediate notifications."""
     mock_send = mocker.patch.object(Apprise, "notify", side_effect=Exception)
 
-    appriser = Appriser()
-    appriser.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
+    make_appriser(add_noop=True)
 
     # Simulate an uncaught exception
     sys.excepthook(ValueError, ValueError("Test exception"), None)
@@ -63,8 +59,7 @@ def test_uncaught_threading_exception_hook_with_non_default_existing_hook(mocker
 
     assert threading.excepthook == my_global_exception_hook
 
-    appriser = Appriser()
-    appriser.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
+    make_appriser(add_noop=True)
 
     assert threading.excepthook != my_global_exception_hook, "Exception hook was not replaced."
 
@@ -80,8 +75,7 @@ def test_uncaught_threading_exception_hook_with_default_existing_hook(mocker):
     """Test that uncaught exceptions trigger immediate notifications."""
     mock_send = mocker.patch.object(Apprise, "notify", side_effect=Exception)
 
-    appriser = Appriser()
-    appriser.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
+    make_appriser(add_noop=True)
 
     # Simulate an uncaught exception
     threading.excepthook(ExceptHookArgs((ValueError, ValueError("Test exception"), None, None)))
@@ -93,9 +87,7 @@ def test_uncaught_threading_exception_hook_with_default_existing_hook(mocker):
 def test_multiple_apprise_objects_with_non_default_existing_hook(mocker):
     """Test that uncaught exceptions trigger immediate notifications."""
     mock_send = mocker.patch.object(Apprise, "notify", side_effect=Exception)
-    _1 = Appriser()
-    _1.add(NoOpNotifier())  # a service must be configured for notify() to be attempted
-    _2 = Appriser()
-    _2.add(NoOpNotifier())
+    _1 = make_appriser(add_noop=True)
+    _2 = make_appriser(add_noop=True)
     sys.excepthook(ValueError, ValueError("Test exception"), None)
     mock_send.assert_called_once()

--- a/tests/test_logprise.py
+++ b/tests/test_logprise.py
@@ -4,9 +4,10 @@ from logging import NullHandler, StreamHandler
 
 import pytest
 from apprise import NotifyFormat, NotifyType
+from conftest import make_appriser
 from loguru import logger
 
-from logprise import Appriser, InterceptHandler
+from logprise import InterceptHandler
 
 
 def test_intercept_handler_forwards_to_loguru():
@@ -16,7 +17,7 @@ def test_intercept_handler_forwards_to_loguru():
     standard_logger.setLevel(logging.DEBUG)
 
     # Create an Appriser to capture the logs
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # Log using standard logging
     test_message = "Test log message"
@@ -30,7 +31,7 @@ def test_intercept_handler_forwards_to_loguru():
 
 def test_appriser_notification_levels():
     """Test that Appriser respects different notification levels"""
-    appriser = Appriser(apprise_trigger_level="WARNING")
+    appriser = make_appriser(apprise_trigger_level="WARNING")
 
     # These should be captured
     logger.warning("Test warning")
@@ -73,7 +74,7 @@ def test_send_notification(apprise_noop):
 
 def test_send_notification_empty():
     """Test sending notification with no triggers"""
-    appriser = Appriser(apprise_trigger_level="ERROR")
+    appriser = make_appriser(apprise_trigger_level="ERROR")
 
     # Log messages below notification level
     logger.debug("Debug message")
@@ -94,7 +95,7 @@ def test_send_notification_discards_buffer_when_no_services(mocker):
     Skipping the call avoids apprise logging 'There are no service(s) to notify' on every
     flush; dropping the buffer avoids accumulating undeliverable logs forever.
     """
-    appriser = Appriser(apprise_trigger_level="ERROR")
+    appriser = make_appriser(apprise_trigger_level="ERROR")
     assert len(appriser.apprise_obj) == 0  # no services configured
 
     logger.error("Boom")
@@ -137,7 +138,7 @@ def test_send_notification_buffer_kept_when_notify_reports_failure(mocker, appri
 
 def test_intercept_skips_setup_for_already_handled_logger():
     """A logger already flagged as handled does not get the interceptor re-attached."""
-    Appriser()  # patches logging.Logger._log
+    make_appriser()  # patches logging.Logger._log
 
     already_handled = logging.getLogger("test.already.handled")
     already_handled._has_been_handled_by_interceptor = True
@@ -146,6 +147,16 @@ def test_intercept_skips_setup_for_already_handled_logger():
     already_handled.error("message")
 
     assert not any(isinstance(h, InterceptHandler) for h in already_handled.handlers)
+
+
+def test_install_is_idempotent(mocker):
+    """A second install() is a no-op and does not re-run the global side effects."""
+    appriser = make_appriser()  # installs once
+
+    spy = mocker.patch.object(appriser, "_setup_interception_handler")
+    appriser.install()  # already armed -> early return
+
+    spy.assert_not_called()
 
 
 def test_config_file_loading(tmp_path, mocker):
@@ -157,7 +168,7 @@ def test_config_file_loading(tmp_path, mocker):
     # Create a temporary config file
     config_path.write_text("urls:\n      - mailto://localhost?from=me@local.be&to=you@local.be")
 
-    appriser = Appriser()
+    appriser = make_appriser()
     # If config is loaded successfully, urls will be populated
     assert len(appriser.apprise_obj) == 1
 
@@ -187,7 +198,7 @@ def test_multiple_notification_batching(apprise_noop):
 def test_notification_level_changes():
     """Test changing notification levels and verifying correct message capture"""
     # Initialize with WARNING level
-    appriser = Appriser(apprise_trigger_level="WARNING")
+    appriser = make_appriser(apprise_trigger_level="WARNING")
 
     # First batch: WARNING level
     logger.info("Info message 1")
@@ -221,7 +232,7 @@ def test_notification_level_changes():
 
 def test_notification_level_edge_cases():
     """Test edge cases for notification levels"""
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # Test setting levels in different formats
     appriser.notification_level = "DEBUG"  # string
@@ -253,7 +264,7 @@ def test_custom_log_level():
     standard_logger.setLevel(custom_level_num)
 
     # Create Appriser with low threshold to catch all messages
-    appriser = Appriser(apprise_trigger_level="DEBUG")
+    appriser = make_appriser(apprise_trigger_level="DEBUG")
 
     # Log using our custom level
     standard_logger.log(custom_level_num, "Custom level message")
@@ -267,7 +278,7 @@ def test_custom_log_level():
 
 def test_all_standard_levels():
     """Test all standard logging levels are handled correctly"""
-    appriser = Appriser(apprise_trigger_level="DEBUG")
+    appriser = make_appriser(apprise_trigger_level="DEBUG")
 
     # Dictionary of standard logging levels and their expected loguru equivalents
     standard_levels = {
@@ -359,7 +370,7 @@ def test_intercepted_logger_doesnt_output_its_messages(capsys) -> None:
     l2.addHandler(StreamHandler())
     l3 = logging.getLogger("test.logger.sublogger")
     # Create an Appriser to capture the logs
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # Log using standard logging
     test_message = "Test log message"
@@ -382,7 +393,7 @@ def test_intercepted_logger_has_streamhandler(capsys) -> None:
     _log.addHandler(StreamHandler())
 
     # Create an Appriser to capture the logs
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # Log using standard logging
     test_message = "Test log message"

--- a/tests/test_periodic_flush.py
+++ b/tests/test_periodic_flush.py
@@ -4,9 +4,9 @@ import time
 from threading import ExceptHookArgs
 from unittest.mock import MagicMock
 
-from conftest import NoOpNotifier
+from conftest import make_appriser
 
-from logprise import Appriser, logger
+from logprise import logger
 
 
 def test_uncaught_exception_hook(apprise_noop, monkeypatch):
@@ -61,12 +61,11 @@ def test_periodic_flush(apprise_noop, monkeypatch):
     mock_thread.return_value.start.assert_called_once()
 
 
-def test_periodic_flush_integration():
+def test_periodic_flush_integration(apprise_noop):
     """Test the periodic flush actually works (integration test)."""
-    # Create an Appriser with a short flush interval
-    appriser = Appriser(flush_interval=0.2)
-    noop = NoOpNotifier()
-    appriser.add(noop)
+    # Use a short flush interval for the test
+    appriser, noop = apprise_noop
+    appriser.flush_interval = 0.2
 
     # Generate an error log (should be captured)
     logger.error("Test periodic flush")
@@ -85,7 +84,7 @@ def test_periodic_flush_integration():
 
 def test_stop_periodic_flush():
     """Test that stop_periodic_flush properly terminates the flush thread."""
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # Create a mock thread
     mock_thread = MagicMock()
@@ -170,7 +169,7 @@ def test_flush_only_if_buffer_has_content(apprise_noop, monkeypatch):
 
 def test_periodic_flush_stops_on_event_set(mocker):
     """Test that periodic_flush exits when stop_event is set."""
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # Pre-set the stop event before calling _periodic_flush
     appriser._stop_event.set()
@@ -194,7 +193,7 @@ def test_periodic_flush_stops_on_event_set(mocker):
 
 def test_periodic_flush_empty_buffer(mocker):
     """Test that periodic_flush skips sending when buffer is empty."""
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # Clear buffer
     appriser.buffer.clear()
@@ -223,7 +222,7 @@ def test_periodic_flush_empty_buffer(mocker):
 
 def test_stop_periodic_flush_idempotent(mocker):
     """Test that calling stop_periodic_flush twice is safe."""
-    appriser = Appriser()
+    appriser = make_appriser()
 
     # First call
     appriser.stop_periodic_flush()
@@ -245,8 +244,7 @@ def test_stop_periodic_flush_idempotent(mocker):
 
 def test_notify_failure_preserves_buffer(mocker):
     """Test that buffer is not cleared when notification fails."""
-    appriser = Appriser()
-    appriser.add(NoOpNotifier())  # a service must be configured for notify() to run
+    appriser = make_appriser(add_noop=True)
 
     # Mock apprise_obj.notify to return False (failure)
     mocker.patch.object(appriser.apprise_obj, "notify", return_value=False)

--- a/tests/test_setting_flush_interval.py
+++ b/tests/test_setting_flush_interval.py
@@ -1,12 +1,11 @@
 import pytest
 import pytest_mock
-
-from logprise import Appriser
+from conftest import make_appriser
 
 
 def test_appriser_flush_interval_setter(mocker: pytest_mock.MockerFixture):
     """Test setting a valid flush interval."""
-    appriser = Appriser(flush_interval=123)
+    appriser = make_appriser(flush_interval=123)
     stop_periodic_flush_mock = mocker.patch.object(appriser, "stop_periodic_flush")
     start_periodic_flush_mock = mocker.patch.object(appriser, "_start_periodic_flush")
 
@@ -23,7 +22,7 @@ def test_appriser_flush_interval_setter(mocker: pytest_mock.MockerFixture):
 
 def test_appriser_flush_interval_set_to_same_value(mocker: pytest_mock.MockerFixture):
     """Test setting the flush interval to the same value."""
-    appriser = Appriser(flush_interval=123)
+    appriser = make_appriser(flush_interval=123)
     stop_periodic_flush_mock = mocker.patch.object(appriser, "stop_periodic_flush")
     start_periodic_flush_mock = mocker.patch.object(appriser, "_start_periodic_flush")
 
@@ -40,7 +39,7 @@ def test_appriser_flush_interval_set_to_same_value(mocker: pytest_mock.MockerFix
 @pytest.mark.parametrize("interval", [0, -1, -100, "invalid", None])
 def test_appriser_flush_interval_setter_invalid(mocker: pytest_mock.MockerFixture, interval: float | str | None):
     """Test setting an invalid flush interval."""
-    appriser = Appriser()
+    appriser = make_appriser()
     stop_periodic_flush_mock = mocker.patch.object(appriser, "stop_periodic_flush")
     start_periodic_flush_mock = mocker.patch.object(appriser, "_start_periodic_flush")
 


### PR DESCRIPTION
## What

Splits `Appriser` construction from activation. Constructing now sets up **instance-local state only**; all process-global side effects move to a new idempotent `install()` method:

- logging interception
- sys/threading exception hooks
- loguru removal prevention
- atexit cleanup
- periodic flush thread

The module body calls `appriser.install()` right after instantiation, so **importing the package still auto-arms everything exactly as before** — no change for end users.

## Why

`__init__` was doing seven setup steps that installed four global hooks and started a thread. Separating *construction* from *activation* makes the class testable without the global-state gymnastics, and lets an `Appriser` exist without patching the interpreter.

## Bug fix

The `flush_interval` setter is now gated on the installed state, so it no longer starts a thread during construction. This closes a latent bug: passing a non-default `flush_interval` previously started **two** flush threads (one from the setter during `__init__`, one from the explicit `_start_periodic_flush()` at the end), orphaning the first.

## Behavior change to note

Setting `flush_interval` *before* `install()` (or on a never-installed instance) no longer starts a flush thread. Invisible to the import-time singleton; only affects code that constructs its own `Appriser`.

## Tests

- New `make_appriser()` conftest helper builds + installs in one step, with opt-in `add_noop=True` for tests that just need a service present. Every construction routes through it.
- `test_periodic_flush_integration` folded into the `apprise_noop` fixture (it needs the notifier handle).
- Added `test_install_is_idempotent`.

## Verification

- 75 passed
- **100% coverage** (out-of-process `coverage run -m pytest`)
- ruff check + format clean