### PR TITLE
feat(pytest_plugin): autouse fixture clears appriser buffer after every test

### DIFF
--- a/logprise/pytest_plugin.py
+++ b/logprise/pytest_plugin.py
@@ -87,23 +87,24 @@ def _loguru_to_caplog(message: loguru.Message) -> None:
         _state.fixture.handler.emit(log_record)
 
 
-@pytest.hookimpl(wrapper=True)
-def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> Generator[None, object, object]:
-    """Drop buffered logs at the pytest-session boundary.
+@pytest.fixture(autouse=True)
+def _clear_appriser_buffer() -> Generator[None, None, None]:
+    """Hand every test an empty appriser buffer, and release it on teardown.
 
-    Errors emitted during tests (``logger.error(...)`` etc.) accumulate in
-    ``appriser.buffer``. Without this hook, ``atexit`` would later fire
+    Errors emitted during a test (``logger.error(...)`` etc.) accumulate in
+    ``appriser.buffer``. Without this fixture, ``atexit`` would later fire
     :meth:`Appriser.cleanup`, which flushes that buffer to whatever real apprise
     services the developer has configured -- so a green test run still pages /
     mails them with every intentionally-exercised error path.
 
     Mirroring the ``caplog`` fixture's "yield then release in ``finally``" shape,
-    this wrapper hands the buffer back empty at the session boundary. What
-    happens before pytest starts or after pytest returns is the user's domain;
-    inside the session, we leave no buffered records behind.
+    autouse so every test (caplog or not) owns the buffer for its duration and
+    hands it back empty. What happens before pytest starts or after pytest
+    returns is the user's domain; inside the session, we leave no buffered
+    records behind.
     """
     try:
-        return (yield)
+        yield
     finally:
         appriser.buffer.clear()
 

--- a/logprise/pytest_plugin.py
+++ b/logprise/pytest_plugin.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, cast
 import pytest
 from loguru import logger
 
+from logprise import appriser
+
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -83,6 +85,27 @@ def _loguru_to_caplog(message: loguru.Message) -> None:
     # This respects caplog.at_level() context manager
     if log_record.levelno >= _state.fixture.handler.level:
         _state.fixture.handler.emit(log_record)
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> Generator[None, object, object]:
+    """Drop buffered logs at the pytest-session boundary.
+
+    Errors emitted during tests (``logger.error(...)`` etc.) accumulate in
+    ``appriser.buffer``. Without this hook, ``atexit`` would later fire
+    :meth:`Appriser.cleanup`, which flushes that buffer to whatever real apprise
+    services the developer has configured -- so a green test run still pages /
+    mails them with every intentionally-exercised error path.
+
+    Mirroring the ``caplog`` fixture's "yield then release in ``finally``" shape,
+    this wrapper hands the buffer back empty at the session boundary. What
+    happens before pytest starts or after pytest returns is the user's domain;
+    inside the session, we leave no buffered records behind.
+    """
+    try:
+        return (yield)
+    finally:
+        appriser.buffer.clear()
 
 
 @pytest.fixture

--- a/logprise/pytest_plugin.py
+++ b/logprise/pytest_plugin.py
@@ -97,12 +97,15 @@ def _clear_appriser_buffer() -> Generator[None, None, None]:
     services the developer has configured -- so a green test run still pages /
     mails them with every intentionally-exercised error path.
 
-    Mirroring the ``caplog`` fixture's "yield then release in ``finally``" shape,
-    autouse so every test (caplog or not) owns the buffer for its duration and
-    hands it back empty. What happens before pytest starts or after pytest
-    returns is the user's domain; inside the session, we leave no buffered
-    records behind.
+    Mirroring the ``caplog`` fixture's "set up, yield, release in ``finally``"
+    shape, autouse so every test (caplog or not) owns the buffer for its
+    duration: cleared on the way in so the test starts clean (the first test
+    would otherwise inherit whatever buffered during collection / plugin load),
+    cleared again on teardown so atexit's :meth:`Appriser.cleanup` sees nothing
+    to flush. What happens before pytest starts or after pytest returns is the
+    user's domain; inside the session, we leave no buffered records behind.
     """
+    appriser.buffer.clear()
     try:
         yield
     finally:

--- a/tests/test_atexit_does_not_flush_test_logs.py
+++ b/tests/test_atexit_does_not_flush_test_logs.py
@@ -1,12 +1,12 @@
-"""End-to-end check that the pytest plugin clears the buffer at session finish.
+"""End-to-end check that a test's error logs never reach atexit's flush.
 
 Spawns a real pytest subprocess so ``atexit`` actually fires. The inline test
 file registers its own ``atexit`` handler *after* importing logprise, so by
 LIFO order that handler runs *before* :meth:`Appriser.cleanup` -- capturing
 ``len(appriser.buffer)`` at the moment cleanup is about to flush.
 
-If the ``pytest_sessionfinish`` wrapper hook in ``logprise.pytest_plugin`` did
-its job, the buffer is empty by then and the sentinel file reads ``"0"``.
+If the autouse buffer-clearing fixture in ``logprise.pytest_plugin`` did its
+job, the buffer is empty by then and the sentinel file reads ``"0"``.
 """
 
 import subprocess

--- a/tests/test_pytest_sessionfinish_hook.py
+++ b/tests/test_pytest_sessionfinish_hook.py
@@ -1,0 +1,65 @@
+"""End-to-end check that the pytest plugin clears the buffer at session finish.
+
+Spawns a real pytest subprocess so ``atexit`` actually fires. The inline test
+file registers its own ``atexit`` handler *after* importing logprise, so by
+LIFO order that handler runs *before* :meth:`Appriser.cleanup` -- capturing
+``len(appriser.buffer)`` at the moment cleanup is about to flush.
+
+If the ``pytest_sessionfinish`` wrapper hook in ``logprise.pytest_plugin`` did
+its job, the buffer is empty by then and the sentinel file reads ``"0"``.
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_sessionfinish_clears_buffer(tmp_path: Path) -> None:
+    sentinel = tmp_path / "buffer_len.txt"
+    test_file = tmp_path / "test_emits_error.py"
+    test_file.write_text(
+        textwrap.dedent(
+            f"""\
+            import atexit
+            from pathlib import Path
+
+            import apprise
+
+            from logprise import appriser, logger
+
+            # Defend against a developer machine with real apprise config: if the
+            # sessionfinish hook ever regresses, this keeps the subprocess from
+            # paging via real services. The buffer-length sentinel below is the
+            # actual signal we measure.
+            appriser.apprise_obj = apprise.Apprise()
+
+            _SENTINEL = Path({sentinel.as_posix()!r})
+
+
+            def _record_buffer_state() -> None:
+                _SENTINEL.write_text(str(len(appriser.buffer)))
+
+
+            # Registered AFTER logprise's own atexit(cleanup) -> fires FIRST in
+            # LIFO order, capturing the buffer state at the moment cleanup is
+            # about to run.
+            atexit.register(_record_buffer_state)
+
+
+            def test_emits_error() -> None:
+                logger.error("boom")
+            """
+        )
+    )
+
+    subprocess.run(
+        [sys.executable, "-m", "pytest", str(test_file), "-q"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert sentinel.read_text() == "0", (
+        f"Expected appriser.buffer empty at atexit (sessionfinish hook ran); got {sentinel.read_text()!r}"
+    )


### PR DESCRIPTION
Closes #131.

## Problem

A pytest run that exercises an error path leaves the resulting `ERROR`/`CRITICAL` record in `appriser.buffer`. At interpreter exit, `atexit` fires `Appriser.cleanup()`, which calls `send_notification()` and ships everything in the buffer to whatever real apprise services the developer has configured — so a **green** test run still pages / mails them.

Per-rootdir `conftest.py` fixtures don't fix this for sub-package rootdirs (each with its own `[tool.pytest.ini_options]` → separate rootdir). The fix has to live in logprise itself, surfaced via the existing `pytest11` entry point so distribution-metadata resolution activates it in every rootdir automatically.

## Fix

Add an **autouse** fixture to `logprise.pytest_plugin` that mirrors the existing `caplog` fixture's shape — `try / yield / finally` — and clears `appriser.buffer` on teardown. Every test (caplog or not) owns the buffer for its duration and hands it back empty, so `atexit`'s `cleanup()` always sees an empty buffer and `send_notification()` early-returns.

```python
@pytest.fixture(autouse=True)
def _clear_appriser_buffer():
    try:
        yield
    finally:
        appriser.buffer.clear()
```

## Why this shape

- **Per-test scope, not session-wide.** Matches the caplog idiom directly above it: each test owns its lifecycle, hands resources back clean on teardown. Test isolation is explicit — no test sees another test's leftover buffer.
- **`.clear()` over `atexit.unregister(cleanup)`.** `cleanup()` also stops the periodic flush thread and restores excepthooks; unregistering it would throw those out alongside the unwanted notification flush. Empty buffer + atexit cleanup → `send_notification()` early-returns, legitimate teardown still runs.
- **`try / yield / finally`.** Guarantees the clear runs even if the test or another fixture raises.

## Behavior caveat

A user who *intends* end-of-pytest atexit to flush real notifications loses that. It's almost certainly misuse — tests shouldn't lean on atexit — and the workaround is one explicit line: `appriser.send_notification()` at the end of the test where you actually want it.

## Test

End-to-end: spawns a real `pytest` subprocess so `atexit` actually fires. The inline test file registers its own `atexit` handler *after* importing logprise, so by LIFO order it runs *before* `Appriser.cleanup`, capturing `len(appriser.buffer)` at the moment cleanup is about to flush. Assertion: sentinel reads `"0"`.

For safety on a developer machine with real apprise config, the inline test also resets `appriser.apprise_obj` to an empty `Apprise()` — the buffer-length sentinel is the actual signal, but this prevents real paging if the fixture ever regresses.

## Verification

- 76 passed
- **100% coverage** including the new autouse fixture (40 stmts, 4 branches in `pytest_plugin.py`, all covered)
- `ruff` check + format clean
- `stubtest logprise` clean