### PR TITLE
fix: keep the host's root log level and make the per-logger intercept guard trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ logger.error("Error from loguru")
 
 ## How It Works
 
-1. **Automatic interception:** Logprise intercepts both loguru and standard library `logging`, redirecting all logs through a unified interface. Logprise never changes the root logger's level. Set it before the import, or afterwards with `logging.getLogger().setLevel(...)`; a plain `logging.basicConfig(level=...)` after the import is a no-op because the root logger already has a handler
+1. **Automatic interception:** Logprise intercepts both loguru and standard library `logging`, redirecting all logs through a unified interface. Logprise never changes the root logger's level. Set it before the import, or afterwards with `logging.getLogger().setLevel(...)`; a plain `logging.basicConfig(level=...)` after the import is a no-op because the root logger already has a handler. Console handlers are replaced by loguru's own output; file and other handlers are left in place and keep receiving records
 2. **Smart batching:** Messages accumulate until flush interval or program exit
 3. **Exception capture:** Uncaught exceptions are logged and trigger immediate notification
 4. **Multiple services:** Send to multiple notification services simultaneously

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ logger.error("Error from loguru")
 
 ## How It Works
 
-1. **Automatic interception:** Logprise intercepts both loguru and standard library `logging`, redirecting all logs through a unified interface. The root logger's level is left as you configured it, so `logging.basicConfig(level=...)` keeps deciding which standard `logging` records get through
+1. **Automatic interception:** Logprise intercepts both loguru and standard library `logging`, redirecting all logs through a unified interface. Logprise never changes the root logger's level. Set it before the import, or afterwards with `logging.getLogger().setLevel(...)`; a plain `logging.basicConfig(level=...)` after the import is a no-op because the root logger already has a handler
 2. **Smart batching:** Messages accumulate until flush interval or program exit
 3. **Exception capture:** Uncaught exceptions are logged and trigger immediate notification
 4. **Multiple services:** Send to multiple notification services simultaneously

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ logger.error("Error from loguru")
 
 ## How It Works
 
-1. **Automatic interception:** Logprise intercepts both loguru and standard library `logging`, redirecting all logs through a unified interface
+1. **Automatic interception:** Logprise intercepts both loguru and standard library `logging`, redirecting all logs through a unified interface. The root logger's level is left as you configured it, so `logging.basicConfig(level=...)` keeps deciding which standard `logging` records get through
 2. **Smart batching:** Messages accumulate until flush interval or program exit
 3. **Exception capture:** Uncaught exceptions are logged and trigger immediate notification
 4. **Multiple services:** Send to multiple notification services simultaneously

--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -41,6 +41,36 @@ class _UnsetType: ...
 _UNSET: Final = _UnsetType()
 
 
+def _is_console_handler(handler: logging.Handler) -> bool:
+    """A StreamHandler writing to the process console: exactly what loguru's own stderr sink replaces.
+
+    File handlers (StreamHandler subclasses over a file) and capture handlers over in-memory streams,
+    such as pytest's, are the host's business and stay.
+    """
+    stream = getattr(handler, "stream", None)
+    return (
+        isinstance(handler, StreamHandler)
+        and stream is not None
+        and stream in (sys.stdout, sys.stderr, sys.__stdout__, sys.__stderr__)
+    )
+
+
+def _strip_console_handlers(start: logging.Logger) -> None:
+    """Remove console handlers from ``start`` and every ancestor up to the root logger."""
+    current: logging.Logger | None = start
+    while current is not None:
+        for handler in current.handlers.copy():
+            if _is_console_handler(handler):
+                current.removeHandler(handler)
+        current = current.parent
+
+
+def _ensure_intercepted(target: logging.Logger) -> None:
+    """Attach an InterceptHandler to ``target`` unless it already has one."""
+    if not any(isinstance(h, InterceptHandler) for h in target.handlers):
+        target.addHandler(InterceptHandler())
+
+
 # Intercept standard logging calls and forward them to loguru
 class InterceptHandler(logging.Handler):
     LOGGING_FILENAMES: ClassVar[set[str]] = {
@@ -172,10 +202,13 @@ class Appriser:
         self.apprise_obj.add(config)
 
     def _setup_interception_handler(self) -> None:
-        # No level= here: the apprise trigger level is a notification threshold (see accumulate_log),
-        # not the level the host wants to log at. Passing it set the root logger to ERROR and silently
-        # dropped every record below it, for every logger without an explicit level (#170).
-        logging.basicConfig(handlers=[InterceptHandler()], force=True)
+        # The root logger keeps everything the host gave it: its level (the apprise trigger level is a
+        # notification threshold, not a log level; passing it as basicConfig(level=...) once dropped every
+        # record below ERROR, #170) and its non-console handlers. basicConfig(force=True) would close and
+        # remove a host FileHandler; only console handlers go, since loguru's own stderr sink replaces them.
+        root = logging.getLogger()
+        _strip_console_handlers(root)
+        _ensure_intercepted(root)
 
         original_method = logging.Logger._log
 
@@ -185,14 +218,17 @@ class Appriser:
 
         @functools.wraps(original_method)
         def new_log_method(self: logging.Logger, *args: object, **kwargs: object) -> None:
+            # Every call: logging.config.dictConfig/fileConfig replace a logger's handlers wholesale, so a
+            # handler attached only once would be gone for good. Re-attaching is cheap and keeps the
+            # logger intercepted however often the host reconfigures logging.
+            _ensure_intercepted(self)
+
+            # Once per logger: console handlers on it and its ancestors would print every record a second
+            # time next to loguru's output, so they go. Everything else (file handlers, capture handlers,
+            # propagation) is the host's and stays, and doing this once means later host changes stick.
             if not getattr(self, "_has_been_handled_by_interceptor", False):
-                if not any(isinstance(h, InterceptHandler) for h in self.handlers):
-                    self.addHandler(InterceptHandler())
-                for handler in self.handlers.copy():
-                    if isinstance(handler, StreamHandler):
-                        self.removeHandler(handler)
-                self.propagate = False
                 self._has_been_handled_by_interceptor = True
+                _strip_console_handlers(self)
 
             return original_method(self, *args, **kwargs)
 

--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -172,7 +172,10 @@ class Appriser:
         self.apprise_obj.add(config)
 
     def _setup_interception_handler(self) -> None:
-        logging.basicConfig(handlers=[InterceptHandler()], level=self._notification_level, force=True)
+        # No level= here: the apprise trigger level is a notification threshold (see accumulate_log),
+        # not the level the host wants to log at. Passing it set the root logger to ERROR and silently
+        # dropped every record below it, for every logger without an explicit level (#170).
+        logging.basicConfig(handlers=[InterceptHandler()], force=True)
 
         original_method = logging.Logger._log
 
@@ -189,7 +192,7 @@ class Appriser:
                     if isinstance(handler, StreamHandler):
                         self.removeHandler(handler)
                 self.propagate = False
-                self._added_intercept_handler = True
+                self._has_been_handled_by_interceptor = True
 
             return original_method(self, *args, **kwargs)
 

--- a/tests/test_logprise.py
+++ b/tests/test_logprise.py
@@ -232,18 +232,28 @@ def test_intercept_skips_setup_for_already_handled_logger():
 
 
 def test_install_leaves_root_level_alone():
-    """The apprise trigger level is a notification threshold, not the root logger's level (#170)."""
+    """The reproduction from issue #170, nearly verbatim: importing logprise must not reset the root
+    logger's level. The apprise trigger level is a notification threshold, not a log level.
+
+    The example configures the *global* root logger. ``force=True`` is needed here because logprise
+    is already imported in this process (so root already has a handler and a plain ``basicConfig``
+    would be a no-op), and the original root level is restored afterwards. The example also printed
+    ``propagate`` of the "demo" logger; logprise sets that to False by design once it intercepts a
+    logger, so it is not asserted.
+    """
     root = logging.getLogger()
     original_level = root.level
-    root.setLevel(logging.DEBUG)
+    seen: list[str] = []
+    logger.add(seen.append, level=0, format="{message}")
     try:
-        make_appriser()  # default trigger level is ERROR; root must stay at DEBUG
-        assert root.level == logging.DEBUG
+        logging.basicConfig(level=logging.DEBUG, format="%(levelname)s %(name)s %(message)s", force=True)
+        logging.getLogger("demo").info("before")  # printed
 
-        seen: list[str] = []
-        logger.add(seen.append, level=0, format="{message}")
-        logging.getLogger("test.inherits.root").info("still logged")
-        assert any("still logged" in message for message in seen)
+        make_appriser()  # stands in for ``import logprise``, which runs install()
+
+        logging.getLogger("demo").info("after")  # was NOT printed
+        assert root.level == logging.DEBUG  # was 40 (ERROR)
+        assert any("after" in message for message in seen)
     finally:
         root.setLevel(original_level)
 

--- a/tests/test_logprise.py
+++ b/tests/test_logprise.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import re
 from logging import NullHandler, StreamHandler
@@ -218,17 +219,93 @@ def test_send_notification_buffer_kept_when_notify_reports_failure(mocker, appri
     assert len(appriser.buffer) == 1  # not cleared, since the send did not succeed
 
 
-def test_intercept_skips_setup_for_already_handled_logger():
-    """A logger already flagged as handled does not get the interceptor re-attached."""
+def test_flagged_logger_gets_the_interceptor_but_keeps_its_console_handler():
+    """The once-per-logger flag guards only the console-handler strip. A logger flagged as handled still
+    gets an InterceptHandler re-attached on every call (logging.config may have removed it), while a
+    console handler it holds is left alone."""
     make_appriser()  # patches logging.Logger._log
 
-    already_handled = logging.getLogger("test.already.handled")
-    already_handled._has_been_handled_by_interceptor = True
+    flagged = logging.getLogger("test.already.handled")
+    flagged._has_been_handled_by_interceptor = True
+    console = StreamHandler()
+    flagged.addHandler(console)
+    try:
+        flagged.error("message")
 
-    # Routes through the patched _log and takes the "skip setup" branch.
-    already_handled.error("message")
+        assert any(isinstance(h, InterceptHandler) for h in flagged.handlers)
+        assert console in flagged.handlers
+    finally:
+        flagged.removeHandler(console)
 
-    assert not any(isinstance(h, InterceptHandler) for h in already_handled.handlers)
+
+def test_interceptor_is_reattached_after_the_host_replaces_handlers():
+    """logging.config.dictConfig/fileConfig replace a logger's handlers wholesale and may switch off
+    propagation. After such a reconfiguration the next call must re-attach the interceptor, otherwise
+    the logger is silently lost to loguru for the rest of the process."""
+    make_appriser()
+    seen: list[str] = []
+    logger.add(seen.append, level=0, format="{message}")
+    log = logging.getLogger("test.reattach")
+    log.error("first call attaches the interceptor")
+
+    # What a dictConfig entry with its own handler and ``propagate: False`` does to the logger.
+    log.handlers = [NullHandler()]
+    log.propagate = False
+    log.error("second call must still reach loguru")
+
+    assert any("second call must still reach loguru" in message for message in seen)
+
+
+def test_file_handler_on_a_logger_survives_interception(tmp_path):
+    """Only console handlers are replaced by loguru's output; the host's file handlers keep working."""
+    log = logging.getLogger("test.filehandler")
+    handler = logging.FileHandler(tmp_path / "app.log")
+    log.addHandler(handler)
+    try:
+        make_appriser()
+        log.error("kept in the file")
+        handler.flush()
+
+        assert handler in log.handlers
+        assert "kept in the file" in (tmp_path / "app.log").read_text()
+    finally:
+        log.removeHandler(handler)
+        handler.close()
+
+
+def test_root_file_handler_is_kept_open_and_still_receives_child_records(tmp_path):
+    """install() must not close or remove the host's root handlers (basicConfig(force=True) did both),
+    and propagation is left as configured so a child logger's records still reach them."""
+    root = logging.getLogger()
+    handler = logging.FileHandler(tmp_path / "root.log")
+    root.addHandler(handler)
+    try:
+        make_appriser()
+        assert handler in root.handlers
+        assert handler.stream is not None  # not closed
+
+        logging.getLogger("test.child.of.root").error("propagated to the root file")
+        handler.flush()
+        assert "propagated to the root file" in (tmp_path / "root.log").read_text()
+    finally:
+        root.removeHandler(handler)
+        handler.close()
+
+
+def test_capture_handler_on_root_survives_root_logging():
+    """pytest's LogCaptureHandler is a StreamHandler over an in-memory stream; only handlers writing to
+    the process console are stripped, so capture handlers keep seeing root records."""
+    root = logging.getLogger()
+    handler = StreamHandler(io.StringIO())
+    root.addHandler(handler)
+    try:
+        make_appriser()
+        logging.error("logged on the root logger")
+
+        assert handler in root.handlers
+        assert "logged on the root logger" in handler.stream.getvalue()
+    finally:
+        root.removeHandler(handler)
 
 
 def test_install_leaves_root_level_alone():
@@ -238,8 +315,8 @@ def test_install_leaves_root_level_alone():
     The example configures the *global* root logger. ``force=True`` is needed here because logprise
     is already imported in this process (so root already has a handler and a plain ``basicConfig``
     would be a no-op), and the original root level is restored afterwards. The example also printed
-    ``propagate`` of the "demo" logger; logprise sets that to False by design once it intercepts a
-    logger, so it is not asserted.
+    ``propagate`` of the "demo" logger; logprise leaves propagation as the host configured it, so
+    there is nothing to assert.
     """
     root = logging.getLogger()
     original_level = root.level
@@ -258,16 +335,20 @@ def test_install_leaves_root_level_alone():
         root.setLevel(original_level)
 
 
-def test_intercept_setup_runs_once_per_logger():
-    """After the first call the guard trips, so later changes the host makes to the logger stick (#170)."""
+def test_console_handler_strip_runs_once_per_logger():
+    """The console-handler strip runs on a logger's first call only, so a console handler the host adds
+    afterwards sticks (#170)."""
     make_appriser()
     log = logging.getLogger("test.setup.once")
-    log.error("first call sets up interception")
-    assert log.propagate is False
+    log.error("first call strips console handlers")
 
-    log.propagate = True
-    log.error("second call must not undo the host's change")
-    assert log.propagate is True
+    console = StreamHandler()
+    log.addHandler(console)
+    try:
+        log.error("second call must not undo the host's change")
+        assert console in log.handlers
+    finally:
+        log.removeHandler(console)
 
 
 def test_install_is_idempotent(mocker):

--- a/tests/test_logprise.py
+++ b/tests/test_logprise.py
@@ -231,6 +231,35 @@ def test_intercept_skips_setup_for_already_handled_logger():
     assert not any(isinstance(h, InterceptHandler) for h in already_handled.handlers)
 
 
+def test_install_leaves_root_level_alone():
+    """The apprise trigger level is a notification threshold, not the root logger's level (#170)."""
+    root = logging.getLogger()
+    original_level = root.level
+    root.setLevel(logging.DEBUG)
+    try:
+        make_appriser()  # default trigger level is ERROR; root must stay at DEBUG
+        assert root.level == logging.DEBUG
+
+        seen: list[str] = []
+        logger.add(seen.append, level=0, format="{message}")
+        logging.getLogger("test.inherits.root").info("still logged")
+        assert any("still logged" in message for message in seen)
+    finally:
+        root.setLevel(original_level)
+
+
+def test_intercept_setup_runs_once_per_logger():
+    """After the first call the guard trips, so later changes the host makes to the logger stick (#170)."""
+    make_appriser()
+    log = logging.getLogger("test.setup.once")
+    log.error("first call sets up interception")
+    assert log.propagate is False
+
+    log.propagate = True
+    log.error("second call must not undo the host's change")
+    assert log.propagate is True
+
+
 def test_install_is_idempotent(mocker):
     """A second install() is a no-op and does not re-run the global side effects."""
     appriser = make_appriser()  # installs once


### PR DESCRIPTION
Fixes #170, plus two review findings in the same code (the per-logger interception setup).

## Bug 1: root logger level overridden

`_setup_interception_handler` passed the apprise trigger level as `logging.basicConfig(level=...)`. That sets the **root logger's** level (ERROR by default), so every logger without an explicit level inherited it and INFO/DEBUG records were never created. A host configured for DEBUG silently went ERROR-only.

The trigger level is a notification threshold and is already applied in `accumulate_log`, so install no longer touches the root level at all.

## Bug 2: per-logger guard never tripped

The guard read `_has_been_handled_by_interceptor` but the block set `_added_intercept_handler`, so the setup block re-ran on every `_log()` call, re-asserting its changes and undoing any repair the host made afterwards. The block now sets the attribute the guard reads.

## Bug 3: a fixed guard turned the attach into a one-shot

With the guard actually tripping, the InterceptHandler attach was also one-shot. `logging.config.dictConfig` / `fileConfig` replace a logger's handlers wholesale (imports first, `dictConfig` second is the normal startup order for Django, uvicorn, gunicorn, celery), so after one such call the logger was silently lost to loguru for the rest of the process: its records still printed through the host's handler, nothing was ever buffered, no alert was ever sent. The attach now runs on every call (a cheap `any()` over the handlers); only the console-handler strip stays once per logger.

## Bug 4: the strip killed the host's file logging

The strip removed every `StreamHandler`, and `FileHandler`, `RotatingFileHandler`, `TimedRotatingFileHandler`, `WatchedFileHandler` and pytest's `LogCaptureHandler` are all `StreamHandler` subclasses. A `FileHandler` attached to a logger for an audit trail went silent after the import. `basicConfig(force=True)` additionally closed and removed every handler the host had put on the root logger, and `propagate = False` cut child records off from any surviving root handler.

Now only handlers writing to the process console (stdout/stderr) are removed, on the logger and its ancestors, since loguru's own stderr sink replaces them. File handlers, capture handlers and everything else stay, the root logger's handlers are neither closed nor removed, and propagation is left exactly as the host configured it.

## Tests

Written first, red against the previous code:

- `test_install_leaves_root_level_alone`: the issue's reproduction nearly verbatim.
- `test_interceptor_is_reattached_after_the_host_replaces_handlers`: handlers replaced and propagation switched off after the first call; the second call still reaches loguru.
- `test_file_handler_on_a_logger_survives_interception`, `test_root_file_handler_is_kept_open_and_still_receives_child_records`, `test_capture_handler_on_root_survives_root_logging`.

Existing tests changed, because they encoded the behaviour fixed here:

- `test_intercept_skips_setup_for_already_handled_logger` asserted that a flagged logger gets **no** InterceptHandler, which is exactly bug 3. It is now `test_flagged_logger_gets_the_interceptor_but_keeps_its_console_handler`: the flag guards only the strip.
- `test_intercept_setup_runs_once_per_logger` (added earlier in this PR) asserted on `propagate`, which is no longer touched. It is now `test_console_handler_strip_runs_once_per_logger`: a console handler added after the first call survives the second.

`test_intercepted_logger_doesnt_output_its_messages` and `test_intercepted_logger_has_streamhandler` pass unchanged. All other tests unchanged. README gets one sentence on the root level and one on which handlers are replaced.