### PR TITLE
fix: attribute intercepted records to the real call site on Python 3.11+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -75,14 +75,19 @@ class InterceptHandler(logging.Handler):
         except ValueError:
             level = record.levelno
 
-        # Find caller from where originated the logged message
-        frame, depth = logging.currentframe(), 0
-        while self._should_ignore_this_frame(frame):
+        # Find the frame that made the logging call. Start from this very frame and count every
+        # frame skipped: loguru's depth=N means "N frames above the caller of log()", and that
+        # caller is emit() itself. logging.currentframe() is unsuitable as a start: it returns the
+        # frame 3 levels up on Python <= 3.10 but 1 level up on 3.11+, so a fixed offset is wrong
+        # on one of them and overshoots shallow stacks ("call stack is not deep enough").
+        frame, depth = inspect.currentframe(), 0
+        while frame is not None and self._should_ignore_this_frame(frame):
             frame = frame.f_back
             depth += 1
+        if frame is None:
+            depth = 0  # walked off the top (e.g. python -c): attribute to emit() rather than raise
 
-        # Get the actual logger name instead of 'logging'
-        logger_opt = logger.opt(depth=depth + 2, exception=record.exc_info)
+        logger_opt = logger.opt(depth=depth, exception=record.exc_info)
         logger_opt.log(level, record.getMessage())
 
 

--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -69,6 +69,15 @@ class InterceptHandler(logging.Handler):
         # Mark record as handled to prevent duplicate processing
         record._has_been_handled_by_interceptor = True
 
+        # logging promises never to raise out of a logging call: every stdlib handler routes a failure
+        # in its own emit() to handleError(). Keep that promise here too, otherwise a bad %-format in any
+        # library unwinds through the host's logging.error(...) call instead of printing a logging error.
+        try:
+            self._forward(record)
+        except Exception:
+            self.handleError(record)
+
+    def _forward(self, record: logging.LogRecord) -> None:
         # Get corresponding Loguru level if it exists
         try:
             level = logger.level(record.levelname).name
@@ -77,7 +86,7 @@ class InterceptHandler(logging.Handler):
 
         # Find the frame that made the logging call. Start from this very frame and count every
         # frame skipped: loguru's depth=N means "N frames above the caller of log()", and that
-        # caller is emit() itself. logging.currentframe() is unsuitable as a start: it returns the
+        # caller is this method. logging.currentframe() is unsuitable as a start: it returns the
         # frame 3 levels up on Python <= 3.10 but 1 level up on 3.11+, so a fixed offset is wrong
         # on one of them and overshoots shallow stacks ("call stack is not deep enough").
         frame, depth = inspect.currentframe(), 0
@@ -85,9 +94,11 @@ class InterceptHandler(logging.Handler):
             frame = frame.f_back
             depth += 1
         if frame is None:
-            depth = 0  # walked off the top (e.g. python -c): attribute to emit() rather than raise
+            depth = 0  # walked off the top (e.g. python -c): attribute to this handler rather than raise
 
-        logger_opt = logger.opt(depth=depth, exception=record.exc_info)
+        # Carry the originating stdlib logger name: sinks (the pytest plugin, user sinks) can then tell a
+        # forwarded record from a native loguru call and keep the name the host's filters key on.
+        logger_opt = logger.bind(_stdlib_logger=record.name).opt(depth=depth, exception=record.exc_info)
         logger_opt.log(level, record.getMessage())
 
 

--- a/tests/test_intercept_handler.py
+++ b/tests/test_intercept_handler.py
@@ -54,9 +54,9 @@ def test_intercepted_record_points_at_the_stdlib_call_site():
     assert records[-1]["extra"]["_stdlib_logger"] == "test.depth"
 
 
-def test_intercept_falls_back_to_emit_when_every_frame_is_ignored(mocker: pytest_mock.MockerFixture):
+def test_intercept_falls_back_to_the_handler_when_every_frame_is_ignored(mocker: pytest_mock.MockerFixture):
     """If the walk runs off the top of the stack (python -c skips its <string> module frame), the record is
-    attributed to emit() instead of making loguru raise "call stack is not deep enough" into the host."""
+    attributed to the handler instead of making loguru raise "call stack is not deep enough" into the host."""
     make_appriser()
     records: list[dict] = []
     logger.add(lambda message: records.append(message.record), level=0)
@@ -64,7 +64,7 @@ def test_intercept_falls_back_to_emit_when_every_frame_is_ignored(mocker: pytest
 
     logging.getLogger("test.depth").error("no attributable frame")
 
-    assert records[-1]["function"] == "emit"
+    assert records[-1]["function"] == "_forward"
 
 
 def test_bad_format_args_do_not_raise_out_of_the_logging_call(mocker: pytest_mock.MockerFixture):

--- a/tests/test_intercept_handler.py
+++ b/tests/test_intercept_handler.py
@@ -51,6 +51,7 @@ def test_intercepted_record_points_at_the_stdlib_call_site():
 
     assert records[-1]["function"] == "call_site"
     assert records[-1]["name"] == __name__
+    assert records[-1]["extra"]["_stdlib_logger"] == "test.depth"
 
 
 def test_intercept_falls_back_to_emit_when_every_frame_is_ignored(mocker: pytest_mock.MockerFixture):
@@ -64,3 +65,14 @@ def test_intercept_falls_back_to_emit_when_every_frame_is_ignored(mocker: pytest
     logging.getLogger("test.depth").error("no attributable frame")
 
     assert records[-1]["function"] == "emit"
+
+
+def test_bad_format_args_do_not_raise_out_of_the_logging_call(mocker: pytest_mock.MockerFixture):
+    """logging never raises from a logging call: a bad %-format goes to handleError, as with every stdlib
+    handler, instead of unwinding through the host's logging.error(...)."""
+    make_appriser()
+    handle_error = mocker.patch.object(InterceptHandler, "handleError")
+
+    logging.getLogger("test.badformat").error("value: %s %s", 1)  # noqa: PLE1206  (must not raise)
+
+    handle_error.assert_called_once()

--- a/tests/test_intercept_handler.py
+++ b/tests/test_intercept_handler.py
@@ -51,3 +51,16 @@ def test_intercepted_record_points_at_the_stdlib_call_site():
 
     assert records[-1]["function"] == "call_site"
     assert records[-1]["name"] == __name__
+
+
+def test_intercept_falls_back_to_emit_when_every_frame_is_ignored(mocker: pytest_mock.MockerFixture):
+    """If the walk runs off the top of the stack (python -c skips its <string> module frame), the record is
+    attributed to emit() instead of making loguru raise "call stack is not deep enough" into the host."""
+    make_appriser()
+    records: list[dict] = []
+    logger.add(lambda message: records.append(message.record), level=0)
+    mocker.patch.object(InterceptHandler, "_should_ignore_this_frame", return_value=True)
+
+    logging.getLogger("test.depth").error("no attributable frame")
+
+    assert records[-1]["function"] == "emit"

--- a/tests/test_intercept_handler.py
+++ b/tests/test_intercept_handler.py
@@ -72,7 +72,9 @@ def test_bad_format_args_do_not_raise_out_of_the_logging_call(mocker: pytest_moc
     handler, instead of unwinding through the host's logging.error(...)."""
     make_appriser()
     handle_error = mocker.patch.object(InterceptHandler, "handleError")
+    log = logging.getLogger("test.badformat")
+    log.propagate = False  # pytest's own capture handler on root re-raises logging errors by design
 
-    logging.getLogger("test.badformat").error("value: %s %s", 1)  # noqa: PLE1206  (must not raise)
+    log.error("value: %s %s", 1)  # noqa: PLE1206  (must not raise)
 
     handle_error.assert_called_once()

--- a/tests/test_intercept_handler.py
+++ b/tests/test_intercept_handler.py
@@ -1,6 +1,8 @@
 import logging
 
 import pytest_mock
+from conftest import make_appriser
+from loguru import logger
 
 from logprise import InterceptHandler
 
@@ -34,3 +36,18 @@ def test_duplicate_emitted_record(mocker: pytest_mock.MockerFixture):
     handler.emit(record)
 
     assert get_message.call_count == 1  # STILL 1!
+
+
+def test_intercepted_record_points_at_the_stdlib_call_site():
+    """loguru's depth must land on the frame that called logging, not two frames above it."""
+    make_appriser()
+    records: list[dict] = []
+    logger.add(lambda message: records.append(message.record), level=0)
+
+    def call_site() -> None:
+        logging.getLogger("test.depth").error("where was I called from?")
+
+    call_site()
+
+    assert records[-1]["function"] == "call_site"
+    assert records[-1]["name"] == __name__


### PR DESCRIPTION
Found while verifying #170: once INFO records from the standard library actually reach loguru, the issue's own reproduction crashes on Python 3.13.

## Bug 1: wrong frame depth on Python 3.11+

`InterceptHandler.emit` started its frame walk at `logging.currentframe()` and passed `depth + 2` to loguru. The `+ 2` matches Python 3.10, where `currentframe()` returns the frame 3 levels up. Python 3.11 changed it to 1 level up, so on 3.11+ every intercepted record was attributed two frames above its real call site, and any stdlib log call made fewer than three frames below the module top made loguru raise `ValueError: call stack is not deep enough` into the host.

Fix: start the walk from the handler's own frame and count every skipped frame, with a fallback to the handler itself if the walk runs off the top of the stack (for example `python -c`).

## Bug 2: a bad %-format raises out of the host's logging call

`logging.Handler.handle` does not wrap `emit()`; every stdlib handler routes failures in its own `emit` body to `handleError()`, which is why logging is documented never to raise from a logging call. This handler forwarded unguarded, so `logging.error("value: %s %s", 1)` anywhere in the process raised `TypeError` through the caller. It now routes to `handleError` like every other handler.

## Also

The forwarded loguru record carries the originating stdlib logger name as `extra["_stdlib_logger"]`, so sinks can tell a forwarded record from a native loguru call and keep the name host filters key on. The pytest plugin fix builds on this.

## Tests

All written first and red on master: `test_intercepted_record_points_at_the_stdlib_call_site` (`assert 'pytest_pyfunc_call' == 'call_site'`), `test_intercept_falls_back_to_emit_when_every_frame_is_ignored`, and `test_bad_format_args_do_not_raise_out_of_the_logging_call` (`TypeError: not enough arguments for format string`). Python 3.14 is added to the CI test matrix since this is version-sensitive behaviour.