### PR TITLE
fix: clear the buffer once any target delivered, instead of only when all did

### DIFF
--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -318,19 +318,25 @@ class Appriser:
                 self.stop_periodic_flush()
                 self._start_periodic_flush()
 
-    def _periodic_flush(self) -> None:
-        """Periodically flush log buffer."""
-        while not self._stop_event.is_set():
+    def _periodic_flush(self, stop_event: threading.Event | None = None) -> None:
+        """Periodically flush the log buffer until ``stop_event`` (this thread's own) is set."""
+        stop_event = stop_event or self._stop_event
+        while not stop_event.is_set():
             # Wait for the specified interval but allow early termination
-            if self._stop_event.wait(self._flush_interval):
+            if stop_event.wait(self._flush_interval):
                 break
 
             self.send_notification()
 
     def _start_periodic_flush(self) -> None:
         """Start the periodic flush thread."""
-        self._stop_event.clear()
-        self._flush_thread = threading.Thread(target=self._periodic_flush, daemon=True, name="logprise-flush")
+        # Every thread gets its own stop event. Reusing one and clearing it here revived a previous
+        # thread that had been told to stop but was still inside a slow send when the join timed out,
+        # leaving two threads flushing the same buffer.
+        self._stop_event = threading.Event()
+        self._flush_thread = threading.Thread(
+            target=self._periodic_flush, args=(self._stop_event,), daemon=True, name="logprise-flush"
+        )
         self._flush_thread.start()
 
     def add(
@@ -421,17 +427,21 @@ class Appriser:
             logger.trace("No logs to send")
             return
 
+        # Detach the batch before delivering. Records that arrive while a send is in flight (the flush
+        # thread runs concurrently with the host, and a target's own error logging is intercepted
+        # straight back here) then land in the fresh buffer instead of being wiped after the send.
+        batch, self.buffer = self.buffer, []
+
         if not len(self.apprise_obj):
             # No services configured: skip notifying so apprise doesn't log
             # "There are no service(s) to notify" for every flush. Drop the
-            # buffered logs too -- services should have been configured by now,
+            # detached batch too -- services should have been configured by now,
             # and there is nowhere to deliver them, so keeping them only leaks memory.
             logger.trace("No notification services configured; discarding buffered logs")
-            self.clear()
             return
 
         # Format the buffered logs into a single message
-        message = "".join(self.buffer).replace("\r", "")
+        message = "".join(batch).replace("\r", "")
 
         # Default path: deliver the logs as a preformatted HTML block. apprise's TEXT->HTML
         # conversion escapes every space to &nbsp; (apprise.URLBase.escape_html), which mangles
@@ -444,8 +454,8 @@ class Appriser:
 
         # Deliver to each target separately. Apprise.notify() collapses every target into a single
         # bool, so one unreachable target would keep the buffer forever and re-send the whole backlog
-        # to the healthy targets on every flush (#167). Clear as soon as any target took the batch;
-        # a batch nobody could deliver is kept for the next attempt.
+        # to the healthy targets on every flush (#167). The batch is done as soon as any target took
+        # it; a batch nobody could deliver goes back for the next attempt.
         delivered = False
         for server in self.apprise_obj:
             try:
@@ -457,8 +467,8 @@ class Appriser:
                 )
             except BaseException as e:
                 logger.warning(f"Failed to send notification: {e}")
-        if delivered:
-            self.clear()
+        if not delivered:
+            self.buffer[:0] = batch  # ahead of whatever accumulated meanwhile
 
 
 appriser = Appriser()

--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -442,13 +442,23 @@ class Appriser:
         if resolved_format is None:
             body, resolved_format = f"<pre>{html.escape(message)}</pre>", NotifyFormat.HTML
 
-        try:
-            if message and self.apprise_obj.notify(
-                title=title, notify_type=notify_type, body=body, body_format=resolved_format
-            ):
-                self.clear()  # Clear the buffer after sending
-        except BaseException as e:
-            logger.warning(f"Failed to send notification: {e}")
+        # Deliver to each target separately. Apprise.notify() collapses every target into a single
+        # bool, so one unreachable target would keep the buffer forever and re-send the whole backlog
+        # to the healthy targets on every flush (#167). Clear as soon as any target took the batch;
+        # a batch nobody could deliver is kept for the next attempt.
+        delivered = False
+        for server in self.apprise_obj:
+            try:
+                delivered = (
+                    apprise.Apprise(servers=server).notify(
+                        title=title, notify_type=notify_type, body=body, body_format=resolved_format
+                    )
+                    or delivered
+                )
+            except BaseException as e:
+                logger.warning(f"Failed to send notification: {e}")
+        if delivered:
+            self.clear()
 
 
 appriser = Appriser()

--- a/tests/test_atexit_flush_delivers.py
+++ b/tests/test_atexit_flush_delivers.py
@@ -1,0 +1,60 @@
+"""End-to-end check that the atexit flush still delivers to every target (#166).
+
+Spawns a real python subprocess so ``atexit`` fires during interpreter
+shutdown, with two targets: delivered through a single Apprise.notify() they
+would go through a thread pool, which cannot be created during shutdown.
+Per-target delivery never needs one. Each target appends a line to a
+sentinel file when it sends.
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_atexit_flush_delivers_to_every_target(tmp_path: Path) -> None:
+    sentinel = tmp_path / "delivered.txt"
+    script = tmp_path / "log_error_and_exit.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            from pathlib import Path
+
+            import apprise
+            from apprise import NotifyBase, NotifyType
+
+            from logprise import appriser, logger
+
+            _SENTINEL = Path({sentinel.as_posix()!r})
+
+
+            class Sentinel(NotifyBase):
+                secure_protocol = False
+                protocol = ("sentinel",)
+
+                def __init__(self, **kwargs):
+                    super().__init__(secure=False, **kwargs)
+
+                def url(self, privacy=False, *args, **kwargs):
+                    return "sentinel://"
+
+                def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+                    with _SENTINEL.open("a") as fh:
+                        print("delivered", file=fh)
+                    return True
+
+
+            appriser.apprise_obj = apprise.Apprise()  # ignore any real config on this machine
+            appriser.add(Sentinel())
+            appriser.add(Sentinel())  # two targets: a single multi-target notify() would need a thread pool
+
+            logger.error("delivered at exit?")
+            """
+        )
+    )
+
+    result = subprocess.run([sys.executable, script], capture_output=True, text=True, check=True)
+
+    assert "Failed to send notification" not in result.stderr
+    assert sentinel.read_text().count("delivered") == 2

--- a/tests/test_logprise.py
+++ b/tests/test_logprise.py
@@ -205,19 +205,6 @@ def test_clear_discards_buffer_but_keeps_services(apprise_noop):
     assert len(appriser.apprise_obj) == 1  # services are preserved
 
 
-def test_send_notification_buffer_kept_when_notify_reports_failure(mocker, apprise_noop):
-    """When notify() reports failure, the buffer is kept for the next attempt."""
-    appriser, _ = apprise_noop
-
-    logger.error("Boom")
-    assert len(appriser.buffer) == 1
-
-    mocker.patch.object(Apprise, "notify", return_value=False)
-    appriser.send_notification()
-
-    assert len(appriser.buffer) == 1  # not cleared, since the send did not succeed
-
-
 def test_partial_delivery_clears_buffer(mocker, apprise_noop):
     """One unreachable target must not keep the buffer, or the healthy targets get the whole backlog
     re-sent on every flush (#167)."""
@@ -260,6 +247,19 @@ def test_records_logged_during_delivery_survive_the_send(mocker, apprise_noop):
     assert "connection reset" not in healthy.calls[0]["body"]
     assert len(appriser.buffer) == 1
     assert "connection reset during delivery" in appriser.buffer[0]
+
+
+def test_send_notification_buffer_kept_when_notify_reports_failure(mocker, apprise_noop):
+    """When notify() reports failure, the buffer is kept for the next attempt."""
+    appriser, _ = apprise_noop
+
+    logger.error("Boom")
+    assert len(appriser.buffer) == 1
+
+    mocker.patch.object(Apprise, "notify", return_value=False)
+    appriser.send_notification()
+
+    assert len(appriser.buffer) == 1  # not cleared, since the send did not succeed
 
 
 def test_intercept_skips_setup_for_already_handled_logger():

--- a/tests/test_logprise.py
+++ b/tests/test_logprise.py
@@ -3,8 +3,8 @@ import re
 from logging import NullHandler, StreamHandler
 
 import pytest
-from apprise import NotifyFormat, NotifyType
-from conftest import make_appriser
+from apprise import Apprise, NotifyFormat, NotifyType
+from conftest import NoOpNotifier, make_appriser
 from loguru import logger
 
 from logprise import InterceptHandler
@@ -77,7 +77,7 @@ def test_html_opt_in_sends_preformatted_block_preserving_whitespace(mocker, appr
     appriser, _noop = apprise_noop
     appriser.body_format = None  # opt into the preformatted-HTML path
     appriser.buffer.append("run:  pkill -f my_worker.py")  # double space + command spaces must survive intact
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
 
     appriser.send_notification()
 
@@ -94,7 +94,7 @@ def test_html_opt_in_escapes_markup_but_leaves_spaces_and_underscores(mocker, ap
     appriser, _noop = apprise_noop
     appriser.body_format = None  # opt into the preformatted-HTML path
     appriser.buffer.append("    obj.__init__() & <x>")  # 4-space indent, dunder, &, angle brackets
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
 
     appriser.send_notification()
 
@@ -105,7 +105,7 @@ def test_explicit_body_format_is_not_wrapped(mocker, apprise_noop):
     """An explicit body_format is honored as-is — the <pre> wrapping is only the None default."""
     appriser, _noop = apprise_noop
     appriser.buffer.append("plain text")
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
 
     appriser.send_notification(body_format=NotifyFormat.TEXT)
 
@@ -119,7 +119,7 @@ def test_instance_body_format_attribute_is_used_when_arg_omitted(mocker, apprise
     appriser, _noop = apprise_noop
     appriser.body_format = NotifyFormat.TEXT  # reconfigure the default rendering
     appriser.buffer.append("plain text")
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
 
     appriser.send_notification()  # omit body_format -> falls back to the instance attribute
 
@@ -133,7 +133,7 @@ def test_explicit_none_forces_html_over_instance_attribute(mocker, apprise_noop)
     appriser, _noop = apprise_noop
     appriser.body_format = NotifyFormat.TEXT  # instance default is plain text...
     appriser.buffer.append("run:  pkill -f x")
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
 
     appriser.send_notification(body_format=None)  # ...but None overrides it for this call
 
@@ -147,7 +147,7 @@ def test_instance_notify_type_attribute_is_used_when_arg_omitted(mocker, apprise
     appriser, _noop = apprise_noop
     appriser.notify_type = NotifyType.FAILURE
     appriser.buffer.append("boom")
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
 
     appriser.send_notification()
 
@@ -183,7 +183,7 @@ def test_send_notification_discards_buffer_when_no_services(mocker):
     logger.error("Boom")
     assert len(appriser.buffer) == 1
 
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
     appriser.send_notification()
 
     mock_notify.assert_not_called()
@@ -212,10 +212,29 @@ def test_send_notification_buffer_kept_when_notify_reports_failure(mocker, appri
     logger.error("Boom")
     assert len(appriser.buffer) == 1
 
-    mocker.patch.object(appriser.apprise_obj, "notify", return_value=False)
+    mocker.patch.object(Apprise, "notify", return_value=False)
     appriser.send_notification()
 
     assert len(appriser.buffer) == 1  # not cleared, since the send did not succeed
+
+
+def test_partial_delivery_clears_buffer(mocker, apprise_noop):
+    """One unreachable target must not keep the buffer, or the healthy targets get the whole backlog
+    re-sent on every flush (#167)."""
+    appriser, healthy = apprise_noop
+    broken = NoOpNotifier()
+    mocker.patch.object(broken, "send", return_value=False)
+    appriser.add(broken)
+
+    logger.error("first error")
+    appriser.send_notification()
+    assert len(healthy.calls) == 1
+    assert appriser.buffer == []
+
+    logger.error("second error")
+    appriser.send_notification()
+    assert len(healthy.calls) == 2
+    assert "first error" not in healthy.calls[-1]["body"]
 
 
 def test_intercept_skips_setup_for_already_handled_logger():
@@ -393,7 +412,7 @@ def test_send_notification_parameters(mocker, apprise_noop):
     appriser, _noop = apprise_noop
     appriser.buffer.append(test_message)
 
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
 
     appriser.send_notification(title=custom_title, notify_type=custom_type, body_format=custom_format)
 
@@ -429,7 +448,7 @@ def test_notification_parameter_types(mocker, apprise_noop, notify_type_param, n
     appriser, _noop = apprise_noop
     appriser.buffer.append(test_message)
 
-    mock_notify = mocker.patch.object(appriser.apprise_obj, "notify")
+    mock_notify = mocker.patch.object(Apprise, "notify")
 
     # Call with the parametrized values
     appriser.send_notification(title=custom_title, notify_type=notify_type_param, body_format=notify_format_param)

--- a/tests/test_logprise.py
+++ b/tests/test_logprise.py
@@ -237,6 +237,31 @@ def test_partial_delivery_clears_buffer(mocker, apprise_noop):
     assert "first error" not in healthy.calls[-1]["body"]
 
 
+def test_records_logged_during_delivery_survive_the_send(mocker, apprise_noop):
+    """A record that arrives while a batch is in flight belongs to the next batch, not the bin.
+
+    A target's own error logging is intercepted straight back into the buffer during notify(),
+    and the flush thread runs concurrently with the host: neither may be wiped by the send.
+    """
+    appriser, healthy = apprise_noop
+
+    def send_and_log_a_new_error(body, title="", **kwargs):
+        healthy.calls.append({"title": title, "body": body})
+        logging.getLogger("net").error("connection reset during delivery")
+        return True
+
+    mocker.patch.object(healthy, "send", side_effect=send_and_log_a_new_error)
+
+    logger.error("first real error")
+    appriser.send_notification()
+
+    assert len(healthy.calls) == 1
+    assert "first real error" in healthy.calls[0]["body"]
+    assert "connection reset" not in healthy.calls[0]["body"]
+    assert len(appriser.buffer) == 1
+    assert "connection reset during delivery" in appriser.buffer[0]
+
+
 def test_intercept_skips_setup_for_already_handled_logger():
     """A logger already flagged as handled does not get the interceptor re-attached."""
     make_appriser()  # patches logging.Logger._log

--- a/tests/test_periodic_flush.py
+++ b/tests/test_periodic_flush.py
@@ -4,6 +4,7 @@ import time
 from threading import ExceptHookArgs
 from unittest.mock import MagicMock
 
+from apprise import Apprise
 from conftest import make_appriser
 
 from logprise import logger
@@ -247,7 +248,7 @@ def test_notify_failure_preserves_buffer(mocker):
     appriser = make_appriser(add_noop=True)
 
     # Mock apprise_obj.notify to return False (failure)
-    mocker.patch.object(appriser.apprise_obj, "notify", return_value=False)
+    mocker.patch.object(Apprise, "notify", return_value=False)
 
     # Add test message to buffer
     logger.error("Test message that should remain in buffer")

--- a/tests/test_periodic_flush.py
+++ b/tests/test_periodic_flush.py
@@ -259,3 +259,34 @@ def test_notify_failure_preserves_buffer(mocker):
     # Verify buffer still contains the message
     assert len(appriser.buffer) == 1
     assert "Test message that should remain in buffer" in appriser.buffer[0].record["message"]
+
+
+def test_changing_flush_interval_mid_send_does_not_revive_the_old_thread(apprise_noop, mocker):
+    """A thread told to stop must not pick up the replacement's stop event and keep flushing beside it."""
+    appriser, noop = apprise_noop
+    in_send, release = threading.Event(), threading.Event()
+
+    def blocking_send(body, title="", **kwargs):
+        in_send.set()
+        release.wait(timeout=5)
+        return True
+
+    mocker.patch.object(noop, "send", side_effect=blocking_send)
+
+    logger.error("something to flush")
+    appriser.flush_interval = 0.05  # restarts the thread with a short interval
+    assert in_send.wait(timeout=5)  # the flush thread is now blocked inside send()
+    old_thread, old_event = appriser._flush_thread, appriser._stop_event
+    join_patch = mocker.patch.object(old_thread, "join")  # the real join would just time out on the blocked thread
+
+    appriser.flush_interval = 60  # stop (times out) and start again while the old thread is mid-send
+    mocker.stop(join_patch)
+
+    assert old_event.is_set()
+    assert appriser._stop_event is not old_event
+    assert appriser._flush_thread is not old_thread
+
+    release.set()
+    old_thread.join(timeout=5)
+    assert not old_thread.is_alive()
+    assert appriser._flush_thread.is_alive()


### PR DESCRIPTION
Fixes #167
Fixes #166

## Bug 1 (#167): one failing target kept the buffer forever

`send_notification` cleared the buffer only when `Apprise.notify()` returned `True`, and that return value is the logical AND across every configured target. One unreachable target therefore kept the buffer forever, and every subsequent flush (the hourly `_periodic_flush` included) re-sent the whole, ever-growing backlog to the healthy targets.

Fix: each target is delivered through its own `Apprise` object, so the result is known per target. The batch is done as soon as any target took it and goes back for the next attempt only when nobody could deliver it. Going through `Apprise` per target keeps apprise's per-service body-format conversion.

The issue's own reproduction (an always-succeeding custom plugin plus `json://localhost:9/`):

```
before: 1 1 / 2 2 / first error re-sent: True
after:  1 0 / 2 0 / first error re-sent: False
```

## Bug 2 (#166): nothing delivered on normal exit

`cleanup()` runs from `atexit`, when a `concurrent.futures` thread pool can no longer be created. With more than one target, a single `Apprise.notify()` delivers through that pool and fails with `can't register atexit after shutdown`. Per-target delivery means every send holds one server, which apprise delivers sequentially without a pool, so the atexit flush works. `tests/test_atexit_flush_delivers.py` spawns a real interpreter with two targets, exits normally, and checks both were delivered (0 of 2 on master). The separate PR for #166 (#174) added an `async_mode` flip that this makes dead code; it is closed and its test lives here.

## Bug 3: records logged while a send was in flight were wiped

The buffer was cleared after the delivery loop, as it stood after the loop. Anything appended in between (a target's own error logging is intercepted straight back into the buffer during `notify()`; the flush thread runs concurrently with the host) was deleted without ever being delivered. The batch is now detached before delivery and, if nobody took it, put back ahead of whatever accumulated meanwhile. `test_records_logged_during_delivery_survive_the_send` was red on the previous commit (`assert 0 == 1` on the buffer length).

## Bug 4: changing flush_interval mid-send revived the old flush thread

`_start_periodic_flush` cleared the shared stop event before starting a new thread. A previous thread still inside a slow send when the one-second join timed out then saw the cleared event and kept flushing beside its replacement, one extra thread per interval change. Every thread now owns its stop event; `self._stop_event` always refers to the current thread's. `test_changing_flush_interval_mid_send_does_not_revive_the_old_thread` was red on the previous commit (the old event came back unset).

## Tests

Written first and red on master or on the previous commit as noted. Existing tests that mocked `notify()` on the appriser's Apprise instance now mock it on the `Apprise` class, since the call no longer goes through that instance; their assertions are unchanged, including the ones that keep the buffer when every target fails. No other existing test changed.

## Not in this PR

The buffer is still unbounded while every target keeps failing (the issue's third suggestion).