### PR TITLE
fix: deliver sequentially from the atexit flush so notifications survive normal exit

### DIFF
--- a/logprise/__init__.py
+++ b/logprise/__init__.py
@@ -367,6 +367,11 @@ class Appriser:
         self.stop_periodic_flush()
 
         if not Appriser._exit_via_unhandled_exception:
+            # cleanup() runs from atexit, once the interpreter is shutting down and thread pools can
+            # no longer be created ("can't register atexit after shutdown"). apprise reaches for one
+            # when several targets are delivered at once, so force sequential delivery here (#166).
+            for server in self.apprise_obj:
+                server.asset.async_mode = False
             self.send_notification()
 
         sys.excepthook = self._original_excepthook

--- a/tests/test_atexit_flush_delivers.py
+++ b/tests/test_atexit_flush_delivers.py
@@ -1,0 +1,58 @@
+"""End-to-end check that the atexit flush actually delivers (#166).
+
+Spawns a real python subprocess so ``atexit`` fires during interpreter
+shutdown, with two targets so apprise would reach for its thread pool. Each
+target appends a line to a sentinel file when it sends.
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_atexit_flush_delivers_to_every_target(tmp_path: Path) -> None:
+    sentinel = tmp_path / "delivered.txt"
+    script = tmp_path / "log_error_and_exit.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            from pathlib import Path
+
+            import apprise
+            from apprise import NotifyBase, NotifyType
+
+            from logprise import appriser, logger
+
+            _SENTINEL = Path({sentinel.as_posix()!r})
+
+
+            class Sentinel(NotifyBase):
+                secure_protocol = False
+                protocol = ("sentinel",)
+
+                def __init__(self, **kwargs):
+                    super().__init__(secure=False, **kwargs)
+
+                def url(self, privacy=False, *args, **kwargs):
+                    return "sentinel://"
+
+                def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+                    with _SENTINEL.open("a") as fh:
+                        print("delivered", file=fh)
+                    return True
+
+
+            appriser.apprise_obj = apprise.Apprise()  # ignore any real config on this machine
+            appriser.add(Sentinel())
+            appriser.add(Sentinel())  # two targets: apprise would use a thread pool
+
+            logger.error("delivered at exit?")
+            """
+        )
+    )
+
+    result = subprocess.run([sys.executable, script], capture_output=True, text=True, check=True)
+
+    assert "Failed to send notification" not in result.stderr
+    assert sentinel.read_text().count("delivered") == 2


### PR DESCRIPTION
Fixes #166

## Bug

`cleanup()` is registered with `atexit`, so it runs once the interpreter is shutting down. With more than one target configured (for example two apprise config files resolving to the same mailbox, as in the report), apprise delivers through a `concurrent.futures` thread pool. Creating that pool during shutdown fails with `can't register atexit after shutdown` if the pool module is first imported then, or `cannot schedule new futures after interpreter shutdown` if it was imported earlier. Either way nothing is delivered, and the only trace is a warning emitted during shutdown.

Reproduced with a script that configures two always-succeeding targets and logs one error:

```
before: Failed to send notification: can't register atexit after shutdown   (0 of 2 delivered)
after:  (2 of 2 delivered)
```

With a single target apprise already delivers sequentially, which is why the explicit `send_notification()` workaround in the report works.

## Fix

Before the final send, `cleanup()` switches every target's asset to synchronous delivery, so the atexit path never needs a thread pool. Two lines in the atexit path only; the exception hooks and the periodic flush run while the interpreter is alive and are unchanged.

## Tests

`test_atexit_flush_delivers_to_every_target` spawns a real interpreter with two sentinel targets, exits normally, and checks both were delivered. Written first: it fails on master with zero deliveries.

## Note

#173 changes delivery to one target at a time, which also avoids the thread pool. This PR is independent of it and keeps the atexit path safe on its own.