### PR TITLE
test: pin caplog fidelity, the failure report's captured log, and multi-instance sink survival

### DIFF
--- a/tests/test_caplog_integration.py
+++ b/tests/test_caplog_integration.py
@@ -96,3 +96,75 @@ def test_multiple_loggers_captured(caplog):
     messages = [record.message for record in caplog.records]
     assert any("From loguru" in msg for msg in messages)
     assert any("From named logger" in msg for msg in messages)
+
+
+def test_records_point_at_the_real_file(caplog):
+    """pathname/filename/lineno/funcName come from the call site, not a namedtuple repr."""
+    with caplog.at_level(logging.INFO):
+        logger.info("where am I")
+
+    record = caplog.records[-1]
+    assert record.pathname == __file__
+    assert record.filename == "test_caplog_integration.py"
+    assert record.funcName == "test_records_point_at_the_real_file"
+    assert record.lineno > 0
+
+
+def test_stdlib_records_keep_their_logger_name(caplog):
+    """A record logged on 'myapp.db' is captured once, under that name."""
+    with caplog.at_level(logging.INFO):
+        logging.getLogger("myapp.db").info("x")
+
+    assert caplog.record_tuples == [("myapp.db", logging.INFO, "x")]
+
+
+def test_native_loguru_records_carry_the_module_name(caplog):
+    with caplog.at_level(logging.INFO):
+        logger.info("native")
+
+    assert caplog.record_tuples == [(__name__, logging.INFO, "native")]
+
+
+def test_non_propagating_logger_is_still_captured(caplog):
+    """A logger the host cut off from root never reaches pytest's handler; the bridge covers it."""
+    log = logging.getLogger("test.noprop")
+    log.propagate = False
+    try:
+        with caplog.at_level(logging.WARNING):
+            log.warning("cut off from root")
+    finally:
+        log.propagate = True
+
+    assert caplog.record_tuples == [("test.noprop", logging.WARNING, "cut off from root")]
+
+
+def test_root_logger_record_is_captured_once(caplog):
+    """This and the next test each log one root record and must each see exactly one; order used to matter."""
+    with caplog.at_level(logging.WARNING):
+        logging.warning("one root record")
+
+    assert caplog.record_tuples == [("root", logging.WARNING, "one root record")]
+
+
+def test_root_logger_record_is_captured_once_again(caplog):
+    with caplog.at_level(logging.WARNING):
+        logging.warning("another root record")
+
+    assert caplog.record_tuples == [("root", logging.WARNING, "another root record")]
+
+
+def test_caplog_filtering_applies(caplog):
+    with caplog.filtering(logging.Filter("zzz")), caplog.at_level(logging.INFO):
+        logging.getLogger("aaa.bbb").info("should be filtered")
+        logger.info("native, also filtered")
+
+    assert caplog.records == []
+
+
+def test_logger_remove_inside_a_test_keeps_capturing(caplog):
+    """The README advertises logger.remove(); it must neither break teardown nor hide later records."""
+    with caplog.at_level(logging.WARNING):
+        logger.remove()
+        logger.warning("after remove")
+
+    assert any("after remove" in record.message for record in caplog.records)

--- a/tests/test_captured_log_report.py
+++ b/tests/test_captured_log_report.py
@@ -1,0 +1,39 @@
+"""A failing test's report keeps its "Captured log call" section.
+
+Spawns a real pytest run on a test that does not request ``caplog`` and logs
+through both the standard library and loguru before failing. pytest's report
+handler sits on the root logger, so both lines must show up there.
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_failure_report_shows_logged_context(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_fails_after_logging.py"
+    test_file.write_text(
+        textwrap.dedent(
+            """\
+            import logging
+
+            from logprise import logger
+
+
+            def test_fails_after_logging():
+                logging.getLogger("svc").warning("stdlib context line")
+                logger.warning("loguru context line")
+                assert False
+            """
+        )
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(test_file), "-q"], capture_output=True, text=True, check=False
+    )
+
+    assert result.returncode == 1
+    assert "Captured log call" in result.stdout
+    assert "stdlib context line" in result.stdout
+    assert "loguru context line" in result.stdout

--- a/tests/test_prevent_removal.py
+++ b/tests/test_prevent_removal.py
@@ -4,7 +4,7 @@ import loguru
 import loguru._simple_sinks
 from conftest import make_appriser
 
-from logprise import appriser, logger
+from logprise import _protected_sinks, _unprotect_sink, appriser, logger
 
 
 def _accumulator_handler_ids() -> list[int]:
@@ -61,3 +61,14 @@ def test_every_installed_appriser_survives_logger_remove():
 
     assert [m.record["message"] for m in appriser.buffer] == ["seen by both"]
     assert [m.record["message"] for m in second.buffer] == ["seen by both"]
+
+
+def test_unprotecting_a_sink_twice_is_a_no_op():
+    """The harness may dispose an instance a test already disposed; the second unprotect must not raise."""
+    second = make_appriser()
+
+    _unprotect_sink(second.accumulate_log)
+    _unprotect_sink(second.accumulate_log)
+
+    assert second.accumulate_log not in _protected_sinks
+    assert _accumulator_handler_ids() == _accumulator_handler_ids()  # and loguru is left consistent

--- a/tests/test_prevent_removal.py
+++ b/tests/test_prevent_removal.py
@@ -2,8 +2,9 @@ import sys
 
 import loguru
 import loguru._simple_sinks
+from conftest import make_appriser
 
-from logprise import logger
+from logprise import appriser, logger
 
 
 def _accumulator_handler_ids() -> list[int]:
@@ -48,3 +49,15 @@ def test_prevent_removal_of_accumulator_not_removing_it():
 
     assert len(core.handlers) == before
     assert _accumulator_handler_ids() == accumulator_ids  # Nothing should have changed!
+
+
+def test_every_installed_appriser_survives_logger_remove():
+    """logger.remove() used to re-add only the most recently installed Appriser's sink: the module-global
+    appriser then buffered nothing for the rest of the process."""
+    second = make_appriser()
+
+    logger.remove()
+    logger.error("seen by both")
+
+    assert [m.record["message"] for m in appriser.buffer] == ["seen by both"]
+    assert [m.record["message"] for m in second.buffer] == ["seen by both"]

--- a/tests/test_prevent_removal.py
+++ b/tests/test_prevent_removal.py
@@ -4,7 +4,8 @@ import loguru
 import loguru._simple_sinks
 from conftest import make_appriser
 
-from logprise import _protected_sinks, _unprotect_sink, appriser, logger
+from logprise import appriser, logger
+from logprise._sinks import protected, unprotect
 
 
 def _accumulator_handler_ids() -> list[int]:
@@ -67,8 +68,8 @@ def test_unprotecting_a_sink_twice_is_a_no_op():
     """The harness may dispose an instance a test already disposed; the second unprotect must not raise."""
     second = make_appriser()
 
-    _unprotect_sink(second.accumulate_log)
-    _unprotect_sink(second.accumulate_log)
+    unprotect(second.accumulate_log)
+    unprotect(second.accumulate_log)
 
-    assert second.accumulate_log not in _protected_sinks
+    assert second.accumulate_log not in protected
     assert _accumulator_handler_ids() == _accumulator_handler_ids()  # and loguru is left consistent

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,26 @@
+"""Direct unit tests for the logprise pytest plugin internals.
+
+The caplog behaviour is covered end to end in test_caplog_integration.py;
+this pins the propagation rule the session sink relies on.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from logprise import pytest_plugin
+
+
+def test_reaches_root_follows_the_propagation_chain():
+    """A logger propagates to root unless it, or an ancestor, has propagate=False."""
+    parent = logging.getLogger("test.reaches")
+    child = logging.getLogger("test.reaches.child")
+    try:
+        assert pytest_plugin._reaches_root("root")
+        assert pytest_plugin._reaches_root("test.reaches.child")
+
+        parent.propagate = False
+        assert not pytest_plugin._reaches_root("test.reaches.child")
+    finally:
+        parent.propagate = True
+        child.propagate = True


### PR DESCRIPTION
Tests only, on top of #179; merge after it. Each of these was written before the implementation and shown red against the old plugin; the evidence per finding is in the review ledger.

- `test_caplog_integration.py`: records carry the real pathname, filename and function (F13); standard-library records keep their logger name and appear exactly once (F14); native loguru records carry the module name; a logger the host cut off from root is still captured; two consecutive tests each see exactly one root record (F15); `caplog.filtering()` applies to both kinds of record (F16); `logger.remove()` inside a test keeps capturing and no longer breaks teardown (F17).
- `test_captured_log_report.py`: a real pytest run on a failing test that does not request `caplog` shows both a stdlib and a loguru line under "Captured log call" (F30).
- `test_prevent_removal.py`: two installed Apprisers both keep accumulating after `logger.remove()`; before the registry the module-global one stayed empty (F8).

112 tests pass with #179 underneath.