### PR TITLE
test: make the removal-prevention tests independent of how sinks are re-added

### DIFF
--- a/tests/test_prevent_removal.py
+++ b/tests/test_prevent_removal.py
@@ -23,14 +23,14 @@ def test_prevent_removal_of_accumulator():
     # The silence autofixture removed everything else; whatever is left is what logprise keeps alive.
     before = len(core.handlers)
     old_ids = _accumulator_handler_ids()
-    assert old_ids
+    assert len(old_ids) == 1  # exactly one accumulator, before ...
 
     logger.remove()  # Means: remove all
 
     assert len(core.handlers) == before
     new_ids = _accumulator_handler_ids()
-    assert new_ids
-    assert not set(old_ids) & set(new_ids), "the accumulator must have been re-added under new ids"
+    assert len(new_ids) == 1  # ... and exactly one after
+    assert old_ids != new_ids, "the accumulator must have been re-added under a new id"
 
 
 def test_prevent_removal_of_accumulator_not_removing_it():
@@ -39,7 +39,7 @@ def test_prevent_removal_of_accumulator_not_removing_it():
 
     before = len(core.handlers)
     accumulator_ids = _accumulator_handler_ids()
-    assert accumulator_ids
+    assert len(accumulator_ids) == 1
 
     mock_id = logger.add(sys.stderr)
     assert len(core.handlers) == before + 1

--- a/tests/test_prevent_removal.py
+++ b/tests/test_prevent_removal.py
@@ -6,43 +6,45 @@ import loguru._simple_sinks
 from logprise import logger
 
 
+def _accumulator_handler_ids() -> list[int]:
+    """Ids of every loguru handler whose sink is an ``Appriser.accumulate_log`` bound method."""
+    return [
+        handler_id
+        for handler_id, handler in logger._core.handlers.items()
+        if type(handler._sink) is loguru._simple_sinks.CallableSink
+        and "bound method Appriser.accumulate_log" in str(handler._sink._function)
+    ]
+
+
 def test_prevent_removal_of_accumulator():
     """Test that Appriser keeps adding its interception"""
     core = logger._core
 
-    assert len(core.handlers) == 1  # 1 because we have a silence-autofixture
-
-    current_id: int = next(iter(core.handlers))
-    assert type(core.handlers[current_id]._sink) is loguru._simple_sinks.CallableSink
-
-    old_sink_function = core.handlers[current_id]._sink._function
-    assert "bound method Appriser.accumulate_log" in str(old_sink_function)
+    # The silence autofixture removed everything else; whatever is left is what logprise keeps alive.
+    before = len(core.handlers)
+    old_ids = _accumulator_handler_ids()
+    assert old_ids
 
     logger.remove()  # Means: remove all
 
-    assert len(core.handlers) == 1
-    assert current_id not in core.handlers, f"'{current_id}' should have been removed!"
-    new_sink_function = core.handlers[current_id + 1]._sink._function
-    assert old_sink_function is not new_sink_function
-    assert "bound method Appriser.accumulate_log" in str(new_sink_function)
+    assert len(core.handlers) == before
+    new_ids = _accumulator_handler_ids()
+    assert new_ids
+    assert not set(old_ids) & set(new_ids), "the accumulator must have been re-added under new ids"
 
 
 def test_prevent_removal_of_accumulator_not_removing_it():
     """Test that Appriser doesn't meddle in other handlers"""
     core = logger._core
 
-    assert len(core.handlers) == 1  # 1 because we have a silence-autofixture
-    accumulator_id: int = next(iter(core.handlers))
+    before = len(core.handlers)
+    accumulator_ids = _accumulator_handler_ids()
+    assert accumulator_ids
 
     mock_id = logger.add(sys.stderr)
-    assert len(core.handlers) == 2
-
-    assert type(core.handlers[accumulator_id]._sink) is loguru._simple_sinks.CallableSink
-
-    old_sink_function = core.handlers[accumulator_id]._sink._function
-    assert "bound method Appriser.accumulate_log" in str(old_sink_function)
+    assert len(core.handlers) == before + 1
 
     logger.remove(mock_id)  # Only remove the mocked handler
 
-    assert len(core.handlers) == 1
-    assert accumulator_id in core.handlers  # Nothing should have changed!
+    assert len(core.handlers) == before
+    assert _accumulator_handler_ids() == accumulator_ids  # Nothing should have changed!


### PR DESCRIPTION
Preparation for #179, which changes how loguru sinks survive `logger.remove()` (every installed Appriser's accumulator will be kept alive, not just the last one). The two removal-prevention tests asserted absolute handler counts (`== 1`, `== 2`) and located the accumulator by position, which only holds while exactly one accumulator sink is kept alive.

They now count relative to what the silence fixture left behind and find accumulators by their sink function (`bound method Appriser.accumulate_log`), so they pass on the current implementation and on #179's. Same intent, same checks: after `logger.remove()` the accumulator is back under a new id, and removing an unrelated sink leaves it untouched.

Passes on master unchanged otherwise (102 tests). Merge before #179.